### PR TITLE
일기 페이지 구성 (controller, repository, service)

### DIFF
--- a/src/main/java/xyz/moodf/diary/controllers/DiaryController.java
+++ b/src/main/java/xyz/moodf/diary/controllers/DiaryController.java
@@ -1,4 +1,70 @@
 package xyz.moodf.diary.controllers;
 
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.util.StringUtils;
+import org.springframework.web.bind.annotation.*;
+import xyz.moodf.diary.services.DiaryService;
+import xyz.moodf.global.annotations.ApplyCommonController;
+import xyz.moodf.global.libs.Utils;
+import xyz.moodf.member.entities.Member;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Controller
+@ApplyCommonController
+@RequiredArgsConstructor
+@RequestMapping("/diary")
+@SessionAttributes("requestLogin")
 public class DiaryController {
+
+    private final Utils utils;
+    private final DiaryService service;
+
+    @GetMapping({"", "/"})
+    public String diary(Model model) {
+        commonProcess("member", model);
+
+        return utils.tpl("diary/diary");
+    }
+
+    @GetMapping("/result")
+    public String result(Model model) {
+        commonProcess("member", model);
+
+        return utils.tpl("diary/result");
+    }
+
+    @PostMapping("/write")
+    public String saveDiary(@RequestParam String title,
+                            @RequestParam String content,
+                            @SessionAttribute("requestLogin") Member member,
+                            Model model) {
+        service.saveDiary(title, content, member);
+
+        return "redirect:/diary/result";
+    }
+
+
+    private void commonProcess(String mode, Model model) {
+        mode = StringUtils.hasText(mode) ? mode : "member";
+        String pageTitle = "";
+        List<String> addCommonScript = new ArrayList<>();
+        List<String> addScript = new ArrayList<>();
+
+        if (mode.equals("member")) {
+            addCommonScript.add("fileManager");
+            addScript.add("/diary");
+            pageTitle = utils.getMessage("일기쓰기");
+
+        } else if (mode.equals("login")) { // 로그인 공통 처리
+            pageTitle = utils.getMessage("일기장_관리");
+        }
+
+        model.addAttribute("addCommonScript", addCommonScript);
+        model.addAttribute("addScript", addScript);
+        model.addAttribute("pageTitle", pageTitle);
+    }
 }

--- a/src/main/java/xyz/moodf/diary/repositories/DiaryRepository.java
+++ b/src/main/java/xyz/moodf/diary/repositories/DiaryRepository.java
@@ -1,0 +1,8 @@
+package xyz.moodf.diary.repositories;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import xyz.moodf.diary.entities.Diary;
+
+public interface DiaryRepository extends JpaRepository<Diary, Long> {
+
+}

--- a/src/main/java/xyz/moodf/diary/services/DiaryService.java
+++ b/src/main/java/xyz/moodf/diary/services/DiaryService.java
@@ -1,0 +1,23 @@
+package xyz.moodf.diary.services;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import xyz.moodf.diary.entities.Diary;
+import xyz.moodf.diary.repositories.DiaryRepository;
+import xyz.moodf.member.entities.Member;
+
+@Service
+@RequiredArgsConstructor
+public class DiaryService {
+
+    private final DiaryRepository diaryRepository;
+
+    public Diary saveDiary(String title, String content, Member member) {
+        Diary diary = new Diary();
+        diary.setTitle(title);
+        diary.setContent(content);
+        diary.setMember(member);
+
+        return diaryRepository.save(diary);
+    }
+}

--- a/src/main/resources/templates/front/diary/dairy.html
+++ b/src/main/resources/templates/front/diary/dairy.html
@@ -1,8 +1,0 @@
-<!DOCTYPE html>
-<html xmlns:th="http://www.thymeleaf.org"
-    xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
-    layout:decorate="~{front/layouts/main}">
-<main layout:fragment="content">
-    <h1>dlfrlwkrtjd</h1>
-</main>
-</html>

--- a/src/main/resources/templates/front/diary/diary.html
+++ b/src/main/resources/templates/front/diary/diary.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org"
+    xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+    layout:decorate="~{front/layouts/main}">
+<main layout:fragment="content" class="container mt-4">
+    <h1>일기장 페이지</h1>
+
+    <form th:action="@{/diary/write}" method="post">
+        <div class="mb-3">
+            <label for="title" class="form-label">제목</label>
+            <input type="text" class="form-control" id="title" name="title" placeholder="제목을 입력하세요">
+        </div>
+
+        <div class="mb-3">
+            <label for="content" class="form-label">내용</label>
+            <textarea class="form-control" id="content" name="content" rows="10" placeholder="오늘의 일기를 작성해 보세요"></textarea>
+        </div>
+
+        <button type="submit" class="btn btn-primary">저장하기</button>
+    </form>
+</main>
+</html>

--- a/src/test/java/xyz/moodf/diary/services/DiaryServiceTest.java
+++ b/src/test/java/xyz/moodf/diary/services/DiaryServiceTest.java
@@ -1,0 +1,62 @@
+package xyz.moodf.diary.services;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+import xyz.moodf.diary.entities.Diary;
+import xyz.moodf.diary.repositories.DiaryRepository;
+import xyz.moodf.member.entities.Member;
+import xyz.moodf.member.repositories.MemberRepository;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@Transactional
+@SpringBootTest
+public class DiaryServiceTest {
+
+    @Autowired
+    private DiaryService diaryService;
+
+    @Autowired
+    private DiaryRepository diaryRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    private Member member;
+
+    @BeforeEach
+    void init() {
+        // 멤버 추가
+        member = new Member();
+        member.setEmail("user01@test.org");
+        member.setPassword("1234");
+        member.setName("사용자01");
+        member.setMobile("01010001000");
+
+        member = memberRepository.save(member);
+    }
+
+    @Test
+    void saveDiaryWithMember() {
+        String title = "오늘의 일기";
+        String content = "아무 노래나 일단 틀어~ 아무거나 신나는 걸로~";
+
+        Diary savedDiary = diaryService.saveDiary(title, content, member);
+
+        // 검증
+        assertNotNull(savedDiary.getDid(), "Diary ID가 null이면 안 됩니다.");
+        assertEquals(title, savedDiary.getTitle(), "제목이 일치해야 합니다.");
+        assertEquals(content, savedDiary.getContent(), "내용이 일치해야 합니다.");
+        assertEquals(member.getSeq(), savedDiary.getMember().getSeq(), "작성자가 일치해야 합니다.");
+
+        // DB에서 확인
+        Diary found = diaryRepository.findById(savedDiary.getDid()).orElseThrow();
+        assertEquals(title, found.getTitle());
+        System.out.println("저장된 일기: " + found);
+    }
+
+}


### PR DESCRIPTION
# 작업 분류
- [x] 기능 추가
- [ ] 기능 보완
- [ ] 코드 리팩토링 (코드 개선)
- [ ] 버그 수정
- [ ] 기타

---

# 작업 개요

Diary 페이지의 기본적인 레이아웃 구성과 일기 제출 시 DB에 저장하는 작업을 수행

---

# 변경 사항

- DiaryController: /diary 페이지는 일기 쓰는 곳, /diary/result 페이지는 결과 띄우는 곳, /diary/write는 submit 했을 때 DB 처리 로직 등을 실행하는 곳
- DiaryService: 일기를 diary 테이블(DB)에 저장

---

# 관련 이슈

- 
- 

---

# 테스트 방법

- DiaryServiceTest: init()에 멤버를 생성/추가하고, saveDiaryWithMember()에서 해당 멤버의 정보로 일기 생성 후 DB에 저장하는 테스트 수행 (findById로 다시 불러와서 출력)
