### PR TITLE
일기 페이지 - 날짜, 날씨 선택

### DIFF
--- a/src/main/java/xyz/moodf/diary/constants/Weather.java
+++ b/src/main/java/xyz/moodf/diary/constants/Weather.java
@@ -1,0 +1,20 @@
+package xyz.moodf.diary.constants;
+
+import lombok.Getter;
+
+@Getter
+public enum Weather {
+    NULL("선택 안 함"),
+    SUNNY("맑음"),
+    CLOUDY("흐림"),
+    RAINY("비"),
+    SNOWY("눈"),
+    STORMY("폭풍"),
+    WINDY("바람");
+
+    private final String description; // 한국어로 출력하기 위해 description 추가
+
+    Weather(String description) {
+        this.description = description;
+    }
+}

--- a/src/main/java/xyz/moodf/diary/controllers/DiaryController.java
+++ b/src/main/java/xyz/moodf/diary/controllers/DiaryController.java
@@ -5,11 +5,15 @@ import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.util.StringUtils;
 import org.springframework.web.bind.annotation.*;
+import xyz.moodf.diary.constants.Weather;
+import xyz.moodf.diary.dtos.DiaryRequest;
+import xyz.moodf.diary.entities.Diary;
 import xyz.moodf.diary.services.DiaryService;
 import xyz.moodf.global.annotations.ApplyCommonController;
 import xyz.moodf.global.libs.Utils;
 import xyz.moodf.member.entities.Member;
 
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -27,6 +31,13 @@ public class DiaryController {
     public String diary(Model model) {
         commonProcess("member", model);
 
+        Diary diary = new Diary();
+        diary.setWeather(Weather.NULL);
+
+        model.addAttribute("today", LocalDate.now());
+        model.addAttribute("diary", diary);
+        model.addAttribute("weatherValues", Weather.values());
+
         return utils.tpl("diary/diary");
     }
 
@@ -38,11 +49,11 @@ public class DiaryController {
     }
 
     @PostMapping("/write")
-    public String saveDiary(@RequestParam String title,
-                            @RequestParam String content,
+    public String saveDiary(@ModelAttribute DiaryRequest diaryRequest,
                             @SessionAttribute("requestLogin") Member member,
                             Model model) {
-        service.saveDiary(title, content, member);
+
+        service.process(diaryRequest, member);
 
         return "redirect:/diary/result";
     }

--- a/src/main/java/xyz/moodf/diary/dtos/DiaryRequest.java
+++ b/src/main/java/xyz/moodf/diary/dtos/DiaryRequest.java
@@ -1,0 +1,24 @@
+package xyz.moodf.diary.dtos;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.Setter;
+import xyz.moodf.diary.constants.Weather;
+
+import java.time.LocalDate;
+
+@Getter @Setter
+public class DiaryRequest {
+    @NotBlank(message = "{NotBlank.diaryRequest.title}")
+    private String title;
+
+    @NotBlank(message = "{NotBlank.diaryRequest.content}")
+    private String content;
+
+    @NotNull(message = "{NotBlank.diaryRequest.date}")  // 크롬 개발자 도구 등으로 값을 지울 경우를 막기 위함
+    private LocalDate date;
+
+    @NotNull(message = "{NotBlank.diaryRequest.weather}")  // 크롬 개발자 도구 등으로 값을 지울 경우를 막기 위함
+    private Weather weather = Weather.NULL;
+}

--- a/src/main/java/xyz/moodf/diary/entities/Diary.java
+++ b/src/main/java/xyz/moodf/diary/entities/Diary.java
@@ -2,8 +2,11 @@ package xyz.moodf.diary.entities;
 
 import jakarta.persistence.*;
 import lombok.Data;
+import xyz.moodf.diary.constants.Weather;
 import xyz.moodf.global.entities.BaseEntity;
 import xyz.moodf.member.entities.Member;
+
+import java.time.LocalDate;
 
 @Data
 @Entity
@@ -17,6 +20,12 @@ public class Diary extends BaseEntity {
 
     @Column(length=2000, nullable = false)
     private String content;
+
+    @Column(nullable = false)
+    private LocalDate date;
+
+    @Column(nullable = false)  // DB에서 직접 null로 세팅할 경우를 막기 위해 추가
+    private Weather weather = Weather.NULL;
 
     @ManyToOne(fetch = FetchType.LAZY)
     private Member member;

--- a/src/main/java/xyz/moodf/diary/services/DiaryService.java
+++ b/src/main/java/xyz/moodf/diary/services/DiaryService.java
@@ -2,20 +2,26 @@ package xyz.moodf.diary.services;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import xyz.moodf.diary.dtos.DiaryRequest;
 import xyz.moodf.diary.entities.Diary;
 import xyz.moodf.diary.repositories.DiaryRepository;
 import xyz.moodf.member.entities.Member;
 
 @Service
+@Transactional  // 여러 Repository 메서드 호출이 하나의 트랜잭션 안에서 처리
 @RequiredArgsConstructor
 public class DiaryService {
 
     private final DiaryRepository diaryRepository;
 
-    public Diary saveDiary(String title, String content, Member member) {
+    public Diary process(DiaryRequest request, Member member) {
         Diary diary = new Diary();
-        diary.setTitle(title);
-        diary.setContent(content);
+
+        diary.setTitle(request.getTitle());
+        diary.setContent(request.getContent());
+        diary.setDate(request.getDate());
+        diary.setWeather(request.getWeather());
         diary.setMember(member);
 
         return diaryRepository.save(diary);

--- a/src/main/resources/messages/validations.properties
+++ b/src/main/resources/messages/validations.properties
@@ -20,3 +20,9 @@ Authentication.bad.credential=이메일 또는 비밀번호가 일치하지 않�
 Authentication.disabled=탈퇴한 회원입니다.
 Authentication.account.expired=만료된 계정입니다.
 Authentication.account.locked=사용이 정지된 계정입니다.
+
+# 일기장
+NotBlank.diaryRequest.title=제목을 입력해 주세요.
+NotBlank.diaryRequest.content=내용을 작성해 주세요.
+NotNull.diaryRequest.date=날짜를 선택해 주세요.
+NotNull.diaryRequest.weather=날씨를 선택해 주세요.

--- a/src/main/resources/templates/front/diary/diary.html
+++ b/src/main/resources/templates/front/diary/diary.html
@@ -2,16 +2,36 @@
 <html xmlns:th="http://www.thymeleaf.org"
     xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
     layout:decorate="~{front/layouts/main}">
-<main layout:fragment="content" class="container mt-4">
+<main layout:fragment="content">
     <h1>일기장 페이지</h1>
 
     <form th:action="@{/diary/write}" method="post">
-        <div class="mb-3">
+        <div>
+            <label for="date" class="form-label">날짜</label>
+            <input type="date"
+                   class="form-control"
+                   id="date"
+                   name="date"
+                   th:value="${today}"
+                   th:max="${today}">
+        </div>
+
+        <div>
+            <label for="weather" class="form-label">날씨</label>
+            <select class="form-control" id="weather" name="weather">
+                <option th:each="w : ${weatherValues}"
+                        th:value="${w.name()}"
+                        th:selected="${diary.weather} == ${w}"
+                        th:text="${w.description}"></option>
+            </select>
+        </div>
+
+        <div>
             <label for="title" class="form-label">제목</label>
             <input type="text" class="form-control" id="title" name="title" placeholder="제목을 입력하세요">
         </div>
 
-        <div class="mb-3">
+        <div>
             <label for="content" class="form-label">내용</label>
             <textarea class="form-control" id="content" name="content" rows="10" placeholder="오늘의 일기를 작성해 보세요"></textarea>
         </div>

--- a/src/test/java/xyz/moodf/diary/services/DiaryServiceTest.java
+++ b/src/test/java/xyz/moodf/diary/services/DiaryServiceTest.java
@@ -5,13 +5,14 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
+import xyz.moodf.diary.constants.Weather;
+import xyz.moodf.diary.dtos.DiaryRequest;
 import xyz.moodf.diary.entities.Diary;
 import xyz.moodf.diary.repositories.DiaryRepository;
 import xyz.moodf.member.entities.Member;
 import xyz.moodf.member.repositories.MemberRepository;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import java.time.LocalDate;
 
 @Transactional
 @SpringBootTest
@@ -41,21 +42,36 @@ public class DiaryServiceTest {
     }
 
     @Test
-    void saveDiaryWithMember() {
+    void test1() {
         String title = "오늘의 일기";
         String content = "아무 노래나 일단 틀어~ 아무거나 신나는 걸로~";
 
-        Diary savedDiary = diaryService.saveDiary(title, content, member);
+//        Diary savedDiary = diaryService.process(title, content, member);
+//
+//        // 검증
+//        assertNotNull(savedDiary.getDid(), "Diary ID가 null이면 안 됩니다.");
+//        assertEquals(title, savedDiary.getTitle(), "제목이 일치해야 합니다.");
+//        assertEquals(content, savedDiary.getContent(), "내용이 일치해야 합니다.");
+//        assertEquals(member.getSeq(), savedDiary.getMember().getSeq(), "작성자가 일치해야 합니다.");
+//
+//        // DB에서 확인
+//        Diary found = diaryRepository.findById(savedDiary.getDid()).orElseThrow();
+//        assertEquals(title, found.getTitle());
+//        System.out.println("저장된 일기: " + found);
+    }
 
-        // 검증
-        assertNotNull(savedDiary.getDid(), "Diary ID가 null이면 안 됩니다.");
-        assertEquals(title, savedDiary.getTitle(), "제목이 일치해야 합니다.");
-        assertEquals(content, savedDiary.getContent(), "내용이 일치해야 합니다.");
-        assertEquals(member.getSeq(), savedDiary.getMember().getSeq(), "작성자가 일치해야 합니다.");
+    @Test
+    void test2() {
+        DiaryRequest diaryRequest = new DiaryRequest();
+        diaryRequest.setTitle("오늘의 일기");
+        diaryRequest.setContent("내용");
+        diaryRequest.setDate(LocalDate.now());
+        diaryRequest.setWeather(Weather.RAINY);
+
+        Diary savedDiary = diaryService.process(diaryRequest, member);
 
         // DB에서 확인
         Diary found = diaryRepository.findById(savedDiary.getDid()).orElseThrow();
-        assertEquals(title, found.getTitle());
         System.out.println("저장된 일기: " + found);
     }
 


### PR DESCRIPTION
# 작업 분류
- [x] 기능 추가
- [ ] 기능 보완
- [ ] 코드 리팩토링 (코드 개선)
- [ ] 버그 수정
- [ ] 기타

---

# 작업 개요

- 일기 페이지에 날짜, 날씨 선택 기능 추가
- 날짜: html에서 오늘 날짜를 받아 기본값으로 설정
- 날씨: html에서 Weather.NULL을 기본값으로 설정
- 테스트 진행함.

---

# 변경 사항

- 

---

# 관련 이슈

- 

---

# 테스트 방법

- 멤버 정의 후 일기 데이터 구성하고 DB 테스트
