### PR TITLE
Sentiment 엔티티 구성

### DIFF
--- a/src/main/java/xyz/moodf/diary/entities/Diary.java
+++ b/src/main/java/xyz/moodf/diary/entities/Diary.java
@@ -31,4 +31,7 @@ public class Diary extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @ToString.Exclude
     private Member member;
+
+    @OneToOne(mappedBy = "diary", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    private Sentiment sentiment;
 }

--- a/src/main/java/xyz/moodf/diary/entities/Sentiment.java
+++ b/src/main/java/xyz/moodf/diary/entities/Sentiment.java
@@ -1,0 +1,24 @@
+package xyz.moodf.diary.entities;
+
+import jakarta.persistence.*;
+import lombok.Data;
+import lombok.ToString;
+
+@Data
+@Entity
+public class Sentiment {
+    @Id
+    @GeneratedValue
+    private Long sid;
+
+    @Column(length=2000)
+    private String content;
+
+    @Column(length=2000)
+    private String sentiment;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "did")
+    @ToString.Exclude
+    private Diary diary;
+}

--- a/src/main/java/xyz/moodf/diary/services/DiaryService.java
+++ b/src/main/java/xyz/moodf/diary/services/DiaryService.java
@@ -5,6 +5,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import xyz.moodf.diary.dtos.DiaryRequest;
 import xyz.moodf.diary.entities.Diary;
+import xyz.moodf.diary.entities.Sentiment;
 import xyz.moodf.diary.repositories.DiaryRepository;
 import xyz.moodf.member.entities.Member;
 
@@ -17,12 +18,16 @@ public class DiaryService {
 
     public Diary process(DiaryRequest request, Member member) {
         Diary diary = new Diary();
+        Sentiment sentiment = new Sentiment();
 
         diary.setTitle(request.getTitle());
         diary.setContent(request.getContent());
         diary.setDate(request.getDate());
         diary.setWeather(request.getWeather());
         diary.setMember(member);
+
+        diary.setSentiment(sentiment);
+        sentiment.setDiary(diary);
 
         return diaryRepository.save(diary);
     }


### PR DESCRIPTION
# 작업 분류
- [x] 기능 추가
- [ ] 기능 보완
- [ ] 코드 리팩토링 (코드 개선)
- [ ] 버그 수정
- [ ] 기타

---

# 작업 개요

감정 분석 결과를 저장할 엔티티 구성

Sentiment 엔티티
- Diary와 1:1 관계
- content: 위지윅 에디터로 나온 결과에서 텍스트만 추려 저장 (Diary의 content와 다름)
- sentiment: 분석된 감정 여러 개를 String으로 저장

+ DiaryService에서 일기를 DB에 저장할 때 Sentiment도 양방향으로 set 해서 함께 저장

---

# 변경 사항

- (어떤 것을 수정/보완 했는가? 1)
- (어떤 것을 수정/보완 했는가? 2)

---

# 관련 이슈

- (발생했던 문제 1)
- (발생했던 문제 2)

---

# 테스트 방법

- (어떻게 테스트했는가? 1)
- (어떻게 테스트했는가? 2)
