### PR TITLE
마이페이지의 그래프에서 사용할 Diary 조회 메서드

### DIFF
--- a/src/main/java/xyz/moodf/diary/services/DiaryService.java
+++ b/src/main/java/xyz/moodf/diary/services/DiaryService.java
@@ -31,7 +31,6 @@ public class DiaryService {
 
         Diary diary = new Diary();
 
-
         diary.setMember(member);
         diary.setDate(request.getDate());
         diary.setGid(gid);

--- a/src/main/java/xyz/moodf/mypage/controllers/ApiMyPageController.java
+++ b/src/main/java/xyz/moodf/mypage/controllers/ApiMyPageController.java
@@ -1,41 +1,40 @@
 package xyz.moodf.mypage.controllers;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import xyz.moodf.diary.services.DiaryInfoService;
+import xyz.moodf.global.exceptions.script.AlertBackException;
+import xyz.moodf.global.libs.Utils;
 import xyz.moodf.global.rests.JSONData;
 import xyz.moodf.member.entities.Member;
+import xyz.moodf.member.exceptions.MemberNotFoundException;
 import xyz.moodf.member.libs.MemberUtil;
 
-import java.time.LocalDate;
-import java.time.YearMonth;
-import java.util.LinkedHashMap;
 import java.util.Map;
 
 @RestController
 @RequestMapping("/api/mypage")
 @RequiredArgsConstructor
 public class ApiMyPageController {
-    //private final DiaryService diaryService;
     private final MemberUtil memberUtil;
+    private final DiaryInfoService infoService;
+    private final Utils utils;
 
     @GetMapping("/emotion")
     public JSONData<Map<String, Long>> emotionData(@RequestParam int year, @RequestParam int month) {
         Member member = memberUtil.getMember();
-        YearMonth ym = YearMonth.of(year, month);
-        LocalDate start = ym.atDay(1);
-        LocalDate end = ym.atEndOfMonth();
-        // Map<String, Long> data = diaryService.getMonthlySentimentCounts(member, start, end);
-        // 수정예정
-        Map<String, Long> data = new LinkedHashMap<>();
-        data.put("기쁨", 5L);
-        data.put("슬픔", 3L);
-        data.put("분노", 1L);
-        data.put("불안", 8L);
-        data.put("당황", 2L);
 
-        return new JSONData<>(data);
+        // 필요하면 여기에 유효성 검증 추가
+
+        try {
+            Map<String, Long> result = infoService.getSentimentFrequencies(member.getSeq(), year, month);
+            return new JSONData<>(result);
+        } catch (MemberNotFoundException e) {
+            throw new AlertBackException(utils.getMessage("NotFound.member"), HttpStatus.NOT_FOUND);
+        }
     }
 }


### PR DESCRIPTION
# 작업 분류
- [ ] 기능 추가
- [x] 기능 보완
- [x] 코드 리팩토링 (코드 개선)
- [ ] 버그 수정
- [ ] 기타

---

# 작업 개요

마이페이지의 그래프에서 사용할 Diary 조회 메서드를 추가함.
멤버 seq, 연도, 월을 받아서 멤버가 그 달에 작성한 모든 일기의 대표 감정을 구한 후 Map<감정, 빈도수> 형태로 반환.

---

# 변경 사항

- (어떤 것을 수정/보완 했는가? 1)
- (어떤 것을 수정/보완 했는가? 2)

---

# 관련 이슈

- (발생했던 문제 1)
- (발생했던 문제 2)

---

# 테스트 방법

- (어떻게 테스트했는가? 1)
- (어떻게 테스트했는가? 2)
