### PR TITLE
일기 페이지 버그 수정

### DIFF
--- a/src/main/java/xyz/moodf/diary/controllers/DiaryController.java
+++ b/src/main/java/xyz/moodf/diary/controllers/DiaryController.java
@@ -60,18 +60,19 @@ public class DiaryController {
         commonProcess("diary", model);
 
         Member member = memberUtil.getMember();
-        DiaryRequest form = new DiaryRequest();
 
         Optional<Diary> optional = diaryRepository.findById(new DiaryId(member, date));
         boolean isSaved;
 
         if (!optional.isPresent()) {
 
+            DiaryRequest form = new DiaryRequest();
             form.setDate(date);
             form.setWeather(Weather.NULL);
             form.setGid(UUID.randomUUID().toString());
 
             isSaved = true;
+            model.addAttribute("diaryRequest", form);
 
         } else {
 
@@ -84,11 +85,11 @@ public class DiaryController {
 
             isSaved = false;
 
+            model.addAttribute("diaryRequest", request);
         }
 
         model.addAttribute("today", LocalDate.now());
         model.addAttribute("weatherValues", Weather.values());
-        model.addAttribute("diaryRequest", request);
         model.addAttribute("isSaved", isSaved);
         model.addAttribute("weatherValues", Weather.values());
         model.addAttribute("date", request.getDate());
@@ -100,6 +101,8 @@ public class DiaryController {
     @PostMapping
     public String process(@Valid DiaryRequest form, Errors errors, Model model) {
         commonProcess("diary", model);
+
+        System.out.println("결과 전달 중...");
 
         if (errors.hasErrors()) {
             return utils.tpl("diary/diary");

--- a/src/main/java/xyz/moodf/diary/entities/Diary.java
+++ b/src/main/java/xyz/moodf/diary/entities/Diary.java
@@ -31,7 +31,7 @@ public class Diary extends BaseEntity implements Serializable {
     private String title;
 
     @Lob
-    @Column(nullable = false)
+    @Column(nullable = false, columnDefinition = "LONGTEXT")
     private String content;
 
     @Column(nullable = false, length = 10)  // DB에서 직접 null로 세팅할 경우를 막기 위해 추가

--- a/src/main/java/xyz/moodf/diary/exceptions/SentimentNotFoundException.java
+++ b/src/main/java/xyz/moodf/diary/exceptions/SentimentNotFoundException.java
@@ -1,0 +1,11 @@
+package xyz.moodf.diary.exceptions;
+
+import org.springframework.http.HttpStatus;
+import xyz.moodf.global.exceptions.script.AlertBackException;
+
+public class SentimentNotFoundException extends AlertBackException {
+    public SentimentNotFoundException() {
+        super("NotFound.sentiment", HttpStatus.NOT_FOUND);
+        setErrorCode(true);
+    }
+}

--- a/src/main/java/xyz/moodf/diary/services/SentimentService.java
+++ b/src/main/java/xyz/moodf/diary/services/SentimentService.java
@@ -7,6 +7,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
 import xyz.moodf.diary.dtos.DiaryRequest;
 import xyz.moodf.diary.entities.Sentiment;
+import xyz.moodf.diary.exceptions.SentimentNotFoundException;
 import xyz.moodf.diary.repositories.SentimentRepository;
 
 import java.util.Arrays;
@@ -49,11 +50,12 @@ public class SentimentService {
 //    }
 
     public void update(DiaryRequest form) {
-        Sentiment item = new Sentiment();
-        item.setGid(form.getGid());
-        item.setContent(form.getContent());
+        // content만 수정
+        Sentiment sentiment = sentimentRepository.findById(form.getGid())
+                .orElseThrow(SentimentNotFoundException::new);
+        sentiment.setContent(form.getContent());
 
-        sentimentRepository.saveAndFlush(item);
+        sentimentRepository.saveAndFlush(sentiment);
     }
 
     public List<String> get(String gid) {

--- a/src/main/java/xyz/moodf/member/services/LoginSuccessHandler.java
+++ b/src/main/java/xyz/moodf/member/services/LoginSuccessHandler.java
@@ -26,7 +26,7 @@ public class LoginSuccessHandler implements AuthenticationSuccessHandler {
 
         String redirectUrl = form.getRedirectUrl();
 
-        redirectUrl = StringUtils.hasText(redirectUrl) ? redirectUrl : "/diary";
+        redirectUrl = !StringUtils.hasText(redirectUrl) || "/".equals(redirectUrl) ? "/diary" : redirectUrl;
 
         session.removeAttribute("requestLogin");
 

--- a/src/main/resources/messages/errors.properties
+++ b/src/main/resources/messages/errors.properties
@@ -13,3 +13,4 @@ UnAuthorized.social=소셜 로그인 접근이 제한되었습니다.
 
 # 일기 관련
 NotFound.diary=일기를 찾을 수 없습니다.
+NotFound.sentiment=감정 데이터를 찾을 수 없습니다.


### PR DESCRIPTION
# 작업 분류
- [ ] 기능 추가
- [ ] 기능 보완
- [ ] 코드 리팩토링 (코드 개선)
- [x] 버그 수정
- [ ] 기타

---

# 작업 개요

일기 페이지의 각종 버그 수정

---

# 변경 사항

- '관련 이슈' 참고

---

# 관련 이슈

1. 가끔 로그인 직후에 redirect=/라는 쿼리 스트링으로 인해 사용하지 않는 메인 페이지로 이동하는 문제
-> 해결: LoginSuccessHandler에서 redirect가 `/`이면 무조건 `/diary`로 넘어갈 수 있도록 함.

2. diary 테이블의 content 컬럼이 db에서 tinytext로 정의 되는 문제
-> 해결: columnDefinition = "LONGTEXT"로 컬럼 정의

3. 이미 저장된 일기 vs. 존재하지 않는 일기는 각각 페이지에 전달하는 정보가 달라야 한다. 그러나 존재하지 않는 일기를 새로 만들 때 gid가 새로 만들어져 전달되지 않는 문제 발생 -> 원인: 새로 만든 DiaryRequest form을 전달하지 않고 있었음.
-> 해결: DiaryController의 diary()에서 `diaryRequest`를 전달할 때, 각 상황에 맞게 데이터를 전달하게 함.

4. 감정 분석할 때, sentiment 테이블의 sentiments가 감정으로 채워졌다가 다시 null이 되는 것이 반복되는 문제
-> 원인: SentimentService의 update()에서 sentiment 테이블의 content를 수정할 때마다, 새로운 sentiment를 만들어 그 안에 content와 gid를 넣고 저장하고 있었음. 그래서 내용이 업데이트 될 때마다 sentiments는 null이 되는 것.
-> 해결: sentiment는 이미 존재할 것이기 때문에 gid로 찾아서 그 데이터를 가져오고, 해당 데이터의 content만 수정해서 다시 저장하게 했다.

---

# 테스트 방법

- 
