### PR TITLE
직전 버그 4번 다시 수정

### DIFF
--- a/src/main/java/xyz/moodf/diary/services/SentimentService.java
+++ b/src/main/java/xyz/moodf/diary/services/SentimentService.java
@@ -7,7 +7,6 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
 import xyz.moodf.diary.dtos.DiaryRequest;
 import xyz.moodf.diary.entities.Sentiment;
-import xyz.moodf.diary.exceptions.SentimentNotFoundException;
 import xyz.moodf.diary.repositories.SentimentRepository;
 
 import java.util.Arrays;
@@ -50,12 +49,21 @@ public class SentimentService {
 //    }
 
     public void update(DiaryRequest form) {
-        // content만 수정
-        Sentiment sentiment = sentimentRepository.findById(form.getGid())
-                .orElseThrow(SentimentNotFoundException::new);
-        sentiment.setContent(form.getContent());
+        
+        Sentiment sentiment = sentimentRepository.findById(form.getGid()).orElse(null);
 
-        sentimentRepository.saveAndFlush(sentiment);
+        if (sentiment == null) {
+            // sentiment가 없으면, 새로 추가ㄴ
+            Sentiment newSent = new Sentiment();
+            newSent.setGid(form.getGid());
+            newSent.setContent(form.getContent());
+            newSent.setDone(false);
+            sentimentRepository.saveAndFlush(newSent);
+        } else {
+            // 이미 sentiment가 존재하면, content만 수정
+            sentiment.setContent(form.getContent());
+            sentimentRepository.saveAndFlush(sentiment);
+        }
     }
 
     public List<String> get(String gid) {


### PR DESCRIPTION
# 작업 분류
- [ ] 기능 추가
- [ ] 기능 보완
- [ ] 코드 리팩토링 (코드 개선)
- [x] 버그 수정
- [ ] 기타

---

# 작업 개요

직전에 버그 수정했던 것 중에 4번을 다시 수정했다.

---

# 변경 사항

- '관련 이슈' 참고

---

# 관련 이슈

4. 감정 분석할 때, sentiment 테이블의 sentiments가 감정으로 채워졌다가 다시 null이 되는 것이 반복되는 문제
-> 원인: SentimentService의 update()에서 sentiment 테이블의 content를 수정할 때마다, 새로운 sentiment를 만들어 그 안에 content와 gid를 넣고 저장하고 있었음. 그래서 내용이 업데이트 될 때마다 sentiments는 null이 되는 것. -> 해결: sentiment가 이미 존재하면 gid로 찾아서 그 데이터를 가져오고, 해당 데이터의 content만 수정해서 다시 저장하게 했음. sentiment가 없으면 새로 만들어서 form을 가져온 다음 데이터 추가.

---

# 테스트 방법

- 
